### PR TITLE
Add paragraph field to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -3,6 +3,7 @@ version=1.0
 author=Natan Biesmans <natan.biesmans@hotmail.com>
 maintainer=Natan Biesmans <natan.biesmans@hotmail.com>
 sentence=A library that allows for easy parsing of POST packages.
+paragraph=For parsing incoming POST JSON data.
 category=Data Processing
 url=https://github.com/NatanBiesmans/Arduino-POST-HTTP-Parser
 architectures=avr


### PR DESCRIPTION
When the paragraph field is missing from library.properties, the Arduino IDE does not recognize the library:

- Sketch > Include Library > Add .ZIP Library fails silently.
- Compilation of any code that includes the library fails.
- After manual installation, "Invalid library" warnings are shown every time the libraries are scanned.
- Library Manager index inclusion request is blocked.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format