### PR TITLE
Use the Ethernet library instead of Ethernet2

### DIFF
--- a/postParser.h
+++ b/postParser.h
@@ -3,7 +3,7 @@
 
 
 #include "Arduino.h"
-#include "Ethernet2.h"
+#include "Ethernet.h"
 
 class PostParser {
   public:


### PR DESCRIPTION
As per https://github.com/adafruit/Ethernet2/pull/20, the Ethernet
library now supports W5500 shields. Move to this, as Ethernet2 is
going to be deprecated in the future.