### PR TITLE
Declare support for SAMD chips

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=A library that allows for easy parsing of POST packages.
 paragraph=For parsing incoming POST JSON data.
 category=Data Processing
 url=https://github.com/NatanBiesmans/Arduino-POST-HTTP-Parser
-architectures=avr
+architectures=avr,samd
 includes=postParser.h


### PR DESCRIPTION
The library has been tested and works on SAMD chips, declare it
so as to avoid warnings when compiling projects for SAMD architectures.