### PR TITLE
Update library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -3,6 +3,7 @@ version=1.0
 author=Natan Biesmans <natan.biesmans@hotmail.com>
 maintainer=Natan Biesmans <natan.biesmans@hotmail.com>
 sentence=A library that allows for easy parsing of POST packages.
+paragraph=A library that allows for easy parsing of POST packages.
 category=Data Processing
 url=https://github.com/NatanBiesmans/Arduino-POST-HTTP-Parser
 architectures=avr


### PR DESCRIPTION
Added a "paragraph" to library.properties to get rid of this error: 
`Invalid library found in ~/Documents/Arduino/libraries/Arduino_POST_HTTP_Parser: Missing 'paragraph' from library`.